### PR TITLE
Sales up: pledge email revisions

### DIFF
--- a/lib/sendPendingPledgeConfirmations.js
+++ b/lib/sendPendingPledgeConfirmations.js
@@ -5,7 +5,6 @@ const dateFormat = timeFormat('%x') // %x - the locale’s date
 
 module.exports = async (userId, pgdb, t) => {
   const user = await pgdb.public.users.findOne({id: userId})
-  const address = await pgdb.public.addresses.findOne({id: user.addressId})
 
   const pledges = await pgdb.public.pledges.find({
     userId: user.id,
@@ -13,6 +12,12 @@ module.exports = async (userId, pgdb, t) => {
   })
 
   if (!pledges.length) { return }
+
+  const address = await pgdb.public.addresses.findOne({id: user.addressId})
+
+  const testimonial = await pgdb.public.testimonials.findFirst({
+    userId: user.id
+  })
 
   // get packageOptions which include the NOTEBOOK
   const goodie = await pgdb.public.goodies.findOne({name: 'NOTEBOOK'})
@@ -62,7 +67,10 @@ module.exports = async (userId, pgdb, t) => {
           content: !(payment.method === 'PAYMENTSLIP')
         },
         { name: 'ASK_PERSONAL_INFO',
-          content: (!user.addressId || !user.birthday)
+          content: (!user.addressId || !user.birthday) && pkg.name !== 'DONATE'
+        },
+        { name: 'ASK_TESTIMONIAL',
+          content: !testimonial
         },
         { name: 'VOUCHER_CODES',
           content: pkg.name === 'ABO_GIVE'

--- a/seeds/email_templates/cf_pledge.html
+++ b/seeds/email_templates/cf_pledge.html
@@ -71,7 +71,9 @@
               *|END:IF|*
               <p>Um das Geschenk einzulösen, muss der neue Besitzer, die neue Besitzerin des Codes auf die Seite <a href="https://www.republik.ch/claim">republik.ch/claim</a> gehen. Und die sechs Zeichen dort eintippen.</p>
               *|END:IF|*
+              *|IF:ASK_TESTIMONIAL|*
               <p>Und wenn Sie noch eine oder zwei Minuten frei haben: Posten Sie doch ein Foto auf unserer Republik-Unterstützungs-Seite. Dort werden Sie sich in guter Gesellschaft befinden. Aber egal, wie gut eine Gesellschaft ist: Sie würde durch Sie noch einen Hauch besser werden. Um dabei zu sein, geht es hier lang: <a href="https://www.republik.ch/merci">republik.ch/merci</a>
+              *|END:IF|*
             </p>
             <p>Vielen Dank!</p>
             <p>Ihre Crew von Project R und der Republik</p>


### PR DESCRIPTION
Changes
- update `cf_pledge` template (just for the record, already updated in Mandrill)
- check for existing testimonial before asking
- don't tell donors that they are members, don't ask for address & birthday